### PR TITLE
variable fix with GraphQLRequestDeserializer

### DIFF
--- a/Demo.Azure.Functions.GraphQL/Demo.Azure.Functions.GraphQL.csproj
+++ b/Demo.Azure.Functions.GraphQL/Demo.Azure.Functions.GraphQL.csproj
@@ -4,9 +4,11 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="3.0.0.2026" />
-    <PackageReference Include="GraphQL.Server.Core" Version="4.0.1" />
-    <PackageReference Include="GraphQL.SystemTextJson" Version="3.0.0.2026" />
+    <PackageReference Include="GraphQL" Version="3.2.0" />
+    <PackageReference Include="GraphQL.Server.Core" Version="4.4.0" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="4.4.0" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore.SystemTextJson" Version="4.4.0" />
+    <PackageReference Include="GraphQL.SystemTextJson" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.7" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />

--- a/Demo.Azure.Functions.GraphQL/Infrastructure/Constants.cs
+++ b/Demo.Azure.Functions.GraphQL/Infrastructure/Constants.cs
@@ -4,7 +4,7 @@
     {
         public const string CONNECTION_STRING_SETTING = "CosmosDBConnection";
 
-        public const string DATABASE_NAME = "Demo.Azure.Functions.GraphQL";
+        public const string DATABASE_NAME = "StarWars";
 
         public const string PLANETS_COLLECTION_NAME = "PlanetsCollection";
 


### PR DESCRIPTION
when using variables in the http POST, deserialized variables was null.
using GraphQL.Server.Transports.AspNetCore.SystemTextJson.GraphQLRequestDeserializer it works !

try a httpPost with json body :
http://localhost:7071/api/graphql
{
    "query":"mutation createCharacter($homeworld:Int!,$charInput: CharacterCreationType!) { createCharacter(homeworld:$homeworld,character: $charInput) { characterId } }",
    "variables":{
        "homeworld":4,
       "charInput":{ "name":"aaa","birthYear":"bbb" }
    }
}